### PR TITLE
Fixed animation listener bug in show(int x,int y,AnimationListener listener) method.

### DIFF
--- a/app/src/main/java/me/yugy/github/reveallayout/RevealLayout.java
+++ b/app/src/main/java/me/yugy/github/reveallayout/RevealLayout.java
@@ -100,7 +100,7 @@ public class RevealLayout extends FrameLayout{
     }
 
     public void show(int x, int y, @Nullable Animation.AnimationListener listener) {
-        show(x, y, DEFAULT_DURATION, null);
+        show(x, y, DEFAULT_DURATION, listener);
     }
 
     public void show(int x, int y, int duration) {


### PR DESCRIPTION
Null instance was being passed to show(x,y,duration,listener) method instead of listener instance;