### PR TITLE
The hide animation used wrong base radius.

### DIFF
--- a/app/src/main/java/me/yugy/github/reveallayout/RevealLayout.java
+++ b/app/src/main/java/me/yugy/github/reveallayout/RevealLayout.java
@@ -185,10 +185,11 @@ public class RevealLayout extends FrameLayout{
             throw new RuntimeException("Center point out of range or call method when View is not initialed yet.");
         }
 
+        final float maxRadius = getMaxRadius(x, y);
         if (x != mClipCenterX || y != mClipCenterY) {
             mClipCenterX = x;
             mClipCenterY = y;
-            mClipRadius = getMaxRadius(x, y);
+            mClipRadius = maxRadius
         }
 
         clearAnimation();
@@ -196,7 +197,7 @@ public class RevealLayout extends FrameLayout{
         mAnimation = new Animation() {
             @Override
             protected void applyTransformation(float interpolatedTime, Transformation t) {
-                setClipRadius(getClipRadius() * (1 - interpolatedTime));
+                setClipRadius(maxRadius * (1 - interpolatedTime));
             }
         };
         mAnimation.setInterpolator(new BakedBezierInterpolator());

--- a/app/src/main/java/me/yugy/github/reveallayout/RevealLayout.java
+++ b/app/src/main/java/me/yugy/github/reveallayout/RevealLayout.java
@@ -189,7 +189,7 @@ public class RevealLayout extends FrameLayout{
         if (x != mClipCenterX || y != mClipCenterY) {
             mClipCenterX = x;
             mClipCenterY = y;
-            mClipRadius = maxRadius
+            mClipRadius = maxRadius;
         }
 
         clearAnimation();


### PR DESCRIPTION
The hide animation used wrong base radius to calculate clip radius which causes the hide animation run too fast